### PR TITLE
Djangoを3.2.10にダウングレード

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==4.0
+Django==3.2.10
 mysqlclient==2.1.0
 djangorestframework==3.12.2
 django-cors-headers==3.5.0


### PR DESCRIPTION
Django4.0だとDRFが対応していなかったため