### PR TITLE
スクロールした際にパンくずリストが文字に被る不具合を修正

### DIFF
--- a/node/django_front/src/components/partTime/CheckStore.jsx
+++ b/node/django_front/src/components/partTime/CheckStore.jsx
@@ -55,7 +55,7 @@ export default function CheckStore() {
                             <ListItemIcon>
                                 <LocalPhoneIcon />
                             </ListItemIcon>
-                         <ListItemText primary="店舗電話番号" secondary={testUser.phoneNumber} />
+                        <ListItemText primary="店舗電話番号" secondary={testUser.phoneNumber} />
                         </ListItem>
                         <ListItem disablePadding sx={{ m: 2 }}>
                             <ListItemIcon>

--- a/node/django_front/src/components/partTime/PartTimeHome.jsx
+++ b/node/django_front/src/components/partTime/PartTimeHome.jsx
@@ -12,8 +12,6 @@ import Box from '@mui/material/Box';
 import AddBusinessIcon from '@mui/icons-material/AddBusiness';
 import { Link as routerLink } from 'react-router-dom'
 
-const shifts = ['1月前半シフト', '1月後半シフト', '2月前半シフト', '2月前半シフト', '3月前半シフト', '3月後半シフト'];
-
 export default function PartTimeHome() {
 
   const [users, setUsers] = useState(null)
@@ -52,9 +50,8 @@ export default function PartTimeHome() {
                     })
                     .then(res=>{setUsers(res.data);
                                 console.log(res.data);
-                                //idで新しい順に並び替える
                                 const rangesVal = res.data;
-                                setRanges(rangesVal.sort(sort));
+                                setRanges(rangesVal.sort(sort)); //idで新しい順に並び替える
                                 console.log(ranges);
                             })
                     .catch(err=>{
@@ -94,9 +91,11 @@ export default function PartTimeHome() {
               </Grid>
               <Grid item xs={12}>
                   <font color='#707070' align='center'>
-                    <p>お使いのアカウントはまだどの<br/>
-                    店舗にも所属していません。<br/>申請ボタンを押して店舗に
-                    <br/>申請を送りましょう！
+                    <p>
+                      お使いのアカウントはまだどの<br/>
+                      店舗にも所属していません。<br/>
+                      申請ボタンを押して店舗に<br/>
+                      申請を送りましょう！
                     </p>
                   </font>
               </Grid>
@@ -152,7 +151,7 @@ export default function PartTimeHome() {
   return (
     <>
       <Container component="main" maxWidth="md">
-        <Typography sx={{fontSize:20, position:'fixed', left:'20px', top:'90px'}}>シフト一覧</Typography>
+        <Typography sx={{fontSize:20, position:'absolute', left:'20px', top:'90px'}}>シフト一覧</Typography>
 
         <Box sx={{pt:"50px"}}>
           {ranges.map((val) =>

--- a/node/django_front/src/components/partTime/PartTimeSettings.jsx
+++ b/node/django_front/src/components/partTime/PartTimeSettings.jsx
@@ -68,7 +68,7 @@ export default function PartTimeSettings() {
     return (
         <>
             <Box sx={{ width: '100%', bgcolor: 'background.paper' }}>
-                <Typography sx={{fontSize:20, position:'fixed'}}>設定</Typography>
+                <Typography sx={{fontSize:20, position:'absolute'}}>設定</Typography>
                     <List sx={{pt:"50px"}}>
                         <ListItem disablePadding>
                             <ListItemButton onClick={() => onOpenDialog("PartTimeAccountSettings")}>

--- a/node/django_front/src/components/partTime/ShiftSubmit.jsx
+++ b/node/django_front/src/components/partTime/ShiftSubmit.jsx
@@ -173,6 +173,7 @@ export default function ShiftSubmit() {
         spacing={5}
       >
         <Grid item>
+        <Typography sx={{fontSize:20, position:'absolute', left:'20px', top:'90px'}}>希望シフト提出</Typography>
           <Typography sx={{ mb: 1 }}>勤務可能な日付にチェックを入れ、シフトを提出してください</Typography>
           <TableContainer component={Paper} >
             <Table aria-label="simple table">

--- a/node/django_front/src/components/store/MakeShift.jsx
+++ b/node/django_front/src/components/store/MakeShift.jsx
@@ -139,7 +139,7 @@ return (
     <>
     <LocalizationProvider dateAdapter={AdapterDateFns} locale={ja}> 
         <Container component="main" maxWidth="md"/>
-            <Typography sx={{fontSize:20, position:'fixed', left:'100px'}}>シフト作成</Typography>
+            <Typography sx={{fontSize:20, position:'absolute', left:'100px'}}>シフト作成</Typography>
                 <Box component="form" onSubmit={onSubmit} noValidate>
                     <Grid container
                         sx={{

--- a/node/django_front/src/components/store/Management.jsx
+++ b/node/django_front/src/components/store/Management.jsx
@@ -154,7 +154,7 @@ export default function Management() {
     return (
         <>
         <Container component="main" maxWidth="md" sx={{ mb: 4 }}>
-            <Typography sx={{fontSize:20, position:'fixed', left:'100px'}}>従業員管理</Typography>
+            <Typography sx={{fontSize:20, position:'absolute', left:'100px'}}>従業員管理</Typography>
             <Grid sx={{
                 direction:"column",
                 justifyContent:"center",

--- a/node/django_front/src/components/store/Settings.jsx
+++ b/node/django_front/src/components/store/Settings.jsx
@@ -76,7 +76,7 @@ export default function Settings() {
     return (
         <>
             <Box sx={{ width: '100%', bgcolor: 'background.paper' }}>
-                <Typography sx={{fontSize:20, position:'fixed'}}>設定</Typography>
+                <Typography sx={{fontSize:20, position:'absolute'}}>設定</Typography>
                     <List sx={{pt:"50px"}}>
                         <ListItem disablePadding>
                             <ListItemButton onClick={() => onOpenDialog("AccountSetting")}>

--- a/node/django_front/src/components/store/StaffManager.jsx
+++ b/node/django_front/src/components/store/StaffManager.jsx
@@ -154,7 +154,7 @@ export default function StaffManager() {
   if(!users || !positions) return null;
   return (
     <Container component="main" maxWidth="md">
-      <Typography sx={{fontSize:20, position:'fixed', left:'100px'}}>スタッフ管理</Typography>
+      <Typography sx={{fontSize:20, position:'absolute', left:'100px'}}>スタッフ管理</Typography>
         <Grid
           sx={{
             display: 'flex',

--- a/node/django_front/src/components/store/StoreHome.jsx
+++ b/node/django_front/src/components/store/StoreHome.jsx
@@ -186,7 +186,7 @@ export default function StoreHome(){
           }else {
             return(
               <Container component="main" maxWidth="md">
-                <Typography sx={{fontSize:20, position:'fixed', left:'100px', top:'90px'}}>シフト一覧</Typography>
+                <Typography sx={{fontSize:20, position:'absolute', left:'100px', top:'90px'}}>シフト一覧</Typography>
                 {!untrustedUsers.length == 0 && 
                   <Typography fontSize={18} sx={{ mt:2 }}>{untrustedUsers.length + '人の承認待ちユーザーがいます '} 
                     <Link


### PR DESCRIPTION
スクロールした際にパンくずリストが文字に被る不具合を修正した
・各パンくずリストのCSSのfixed(固定)になっていた部分をabsoluteに変更した